### PR TITLE
Fix admin seed SQL parameter type mismatch

### DIFF
--- a/backend/alembic/versions/8d300e45b937_add_is_admin_column_and_seed_admin.py
+++ b/backend/alembic/versions/8d300e45b937_add_is_admin_column_and_seed_admin.py
@@ -83,9 +83,17 @@ def upgrade() -> None:
         sa.text(
             """
             INSERT INTO users (username, email, hashed_password, is_active, is_admin, created_at)
-            SELECT :username, :email, :password, TRUE, TRUE, :created_at
+            SELECT
+                CAST(:username AS VARCHAR(50)),
+                CAST(:email AS VARCHAR(100)),
+                :password,
+                TRUE,
+                TRUE,
+                :created_at
             WHERE NOT EXISTS (
-                SELECT 1 FROM users WHERE username = :username OR email = :email
+                SELECT 1 FROM users
+                WHERE username = CAST(:username AS VARCHAR(50))
+                   OR email = CAST(:email AS VARCHAR(100))
             )
             """
         ),


### PR DESCRIPTION
## Summary
- cast admin seed parameters to match users table column types to avoid ambiguous parameter errors

## Testing
- `python -m compileall backend`
- `make check-backend` *(fails: /bin/bash: line 1: import: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc33a5dcdc83239a440299672b4089