### PR TITLE
Load .env for database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ library/
 cp backend/.env.example backend/.env
 ```
 
+后端启动时会使用 `python-dotenv` 自动加载 `.env` 文件中的变量，无需手动 `export`。
+
 ### Docker Compose 启动（PostgreSQL）
 
 ```bash

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,10 @@
 import os
+import sys
 from typing import List
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 class Settings:
     # JWT 配置
@@ -39,7 +44,8 @@ class Settings:
 settings = Settings()
 
 if not settings.DATABASE_URL:
-    raise RuntimeError("DATABASE_URL environment variable is required")
+    print("DATABASE_URL is not set; please define it in the environment or .env file")
+    sys.exit(1)
 
 # 向后兼容的常量
 SECRET_KEY = settings.SECRET_KEY

--- a/backend/scripts/wait_for_db.py
+++ b/backend/scripts/wait_for_db.py
@@ -1,6 +1,9 @@
 import os
 import re
+import sys
 import time
+
+from dotenv import load_dotenv
 import psycopg
 
 
@@ -19,9 +22,11 @@ def normalize_db_url(url: str) -> str:
 
 
 def main():
+    load_dotenv()
     database_url_raw = os.getenv("DATABASE_URL")
     if not database_url_raw:
-        raise RuntimeError("DATABASE_URL is not set")
+        print("[wait_for_db] DATABASE_URL is not set; please define it in the environment or .env file")
+        sys.exit(1)
 
     db_url = normalize_db_url(database_url_raw)
     timeout = int(os.getenv("DB_WAIT_TIMEOUT", "30"))


### PR DESCRIPTION
## Summary
- load .env before database wait script and fail gracefully if DATABASE_URL missing
- load .env in settings module and exit with helpful message if DATABASE_URL missing
- document python-dotenv .env support in README

## Testing
- `python -m py_compile backend/scripts/wait_for_db.py backend/app/core/config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc6ffd1fcc83238c0b6bf59e719024