### PR TITLE
Fix Docker Compose env handling and CI

### DIFF
--- a/.env
+++ b/.env
@@ -16,9 +16,9 @@ REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # Database configuration
 POSTGRES_USER=csuser
-POSTGRES_PASSWORD=change_me
+POSTGRES_PASSWORD=password
 POSTGRES_DB=cslibrary
-DATABASE_URL=postgresql+psycopg://csuser:change_me@postgres:5432/cslibrary
+DATABASE_URL=postgresql+psycopg://csuser:password@postgres:5432/cslibrary
 
 # CORS
 CORS_ORIGINS=http://localhost:8080,http://localhost:5173,http://localhost:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,24 +8,32 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      SECRET_KEY: ${{ secrets.SECRET_KEY }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Build services
-        run: docker compose build
+      - name: Prepare .env for CI
+        run: |
+          cat > .env.ci <<'EOF'
+          DATABASE_URL=postgresql+psycopg://csuser:password@postgres:5432/cslibrary
+          ENVIRONMENT=production
+          HOST=0.0.0.0
+          PORT=8000
+          POSTGRES_DB=cslibrary
+          POSTGRES_USER=csuser
+          POSTGRES_PASSWORD=password
+          EOF
 
       - name: Start database
-        run: docker compose up -d postgres
+        run: docker compose --env-file .env.ci up -d postgres
+
+      - name: Build backend
+        run: docker compose --env-file .env.ci build backend
 
       - name: Run migrations
-        run: docker compose run --rm backend alembic upgrade head
+        run: docker compose --env-file .env.ci run --rm backend alembic upgrade head
 
       - name: Run tests
-        run: docker compose run --rm backend pytest
+        run: docker compose --env-file .env.ci run --rm backend pytest -q
 
       - name: Tear down
         if: always()
-        run: docker compose down -v
+        run: docker compose --env-file .env.ci down -v

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,7 +25,8 @@ RUN pip install --upgrade pip setuptools wheel && \
     pip install -r requirements.txt
 
 # Copy application code
-# In development, this will be overridden by volume mount
+# .env files are deliberately excluded via dockerignore to avoid baking secrets
+# into the image. In development, this will be overridden by a volume mount.
 COPY . .
 
 # Create uploads directory

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -12,12 +12,26 @@ from app.core.config import settings
 """
 
 SQLALCHEMY_DATABASE_URL = settings.DATABASE_URL.strip()
+
+# Allow developers to omit the driver in DATABASE_URL. If a plain
+# ``postgresql://`` URL is provided, automatically upgrade it to the
+# required ``postgresql+psycopg://`` form so the application can start
+# without manual tweaks.
+if SQLALCHEMY_DATABASE_URL.startswith("postgresql://") and "+" not in SQLALCHEMY_DATABASE_URL.split("//", 1)[1]:
+    SQLALCHEMY_DATABASE_URL = SQLALCHEMY_DATABASE_URL.replace(
+        "postgresql://", "postgresql+psycopg://", 1
+    )
+
 if not SQLALCHEMY_DATABASE_URL:
-    raise RuntimeError("DATABASE_URL is required (e.g., postgresql+psycopg://user:pass@host:5432/db)")
+    raise RuntimeError(
+        "DATABASE_URL is required (e.g., postgresql+psycopg://user:pass@host:5432/db)"
+    )
 
 url_obj = make_url(SQLALCHEMY_DATABASE_URL)
 if url_obj.drivername not in {"postgresql+psycopg", "postgresql+asyncpg"}:
-    raise RuntimeError("DATABASE_URL must use postgresql+psycopg (or postgresql+asyncpg if async stack)")
+    raise RuntimeError(
+        "DATABASE_URL must use postgresql+psycopg (or postgresql+asyncpg if async stack)"
+    )
 
 engine = create_engine(url_obj, pool_pre_ping=True, future=True)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ services:
   backend:
     build:
       context: ./backend
-      dockerfile: ${BACKEND_DOCKERFILE:-Dockerfile.dev}
+      dockerfile: Dockerfile
+    env_file:
+      - .env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql://csuser:change_me@postgres:5432/cslibrary}
-      SECRET_KEY: ${SECRET_KEY:-change_me}
-      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000}
-      ADMIN_DEFAULT_USERNAME: ${ADMIN_DEFAULT_USERNAME:-admin}
-      ADMIN_DEFAULT_EMAIL: ${ADMIN_DEFAULT_EMAIL:-admin@example.com}
-      ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:-admin123}
+      DATABASE_URL: ${DATABASE_URL}
+      ENVIRONMENT: ${ENVIRONMENT:-production}
+      HOST: ${HOST:-0.0.0.0}
+      PORT: ${PORT:-8000}
     ports:
       - "${BACKEND_PORT:-8000}:8000"
     volumes:
@@ -28,7 +28,9 @@ services:
   frontend:
     build:
       context: ./frontend
-      dockerfile: ${FRONTEND_DOCKERFILE:-Dockerfile.dev}
+      dockerfile: Dockerfile
+    env_file:
+      - .env
     environment:
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:8000}
       NODE_ENV: ${NODE_ENV:-development}
@@ -50,14 +52,16 @@ services:
     build:
       context: ./postgres
       dockerfile: Dockerfile
+    env_file:
+      - .env
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-csuser}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change_me}
-      POSTGRES_DB: ${POSTGRES_DB:-cslibrary}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-csuser} -d ${POSTGRES_DB:-cslibrary}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- use a single root .env with psycopg DSN
- simplify docker-compose to use root env file and explicit backend vars
- add automatic upgrade for plain PostgreSQL URLs
- run CI with generated .env.ci and docker compose commands

## Testing
- `docker compose --env-file .env.ci up -d postgres` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd367b45c483239301b411fe219b5a