### PR TITLE
fix frontend nginx readiness and CI diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,40 +81,40 @@ jobs:
           docker compose --env-file .env.ci ps
           docker compose --env-file .env.ci logs --no-color --tail=200 frontend || true
 
-      - name: Nginx integration check (wait up to 30s)
-        run: |
-          docker compose --env-file .env.ci exec -T frontend sh -lc '
-            i=0
-            until wget -qS --spider http://localhost/ 2>&1 | tr -d "\r" | grep -qiE "^\s*Content-Type:\s*text/html(\s*;.*)?$"; do
-              i=$((i+1))
-              if [ $i -ge 15 ]; then
-                echo "Nginx not serving text/html after ~30s"
-                exit 1
-              fi
-              echo "Waiting for Nginx static page... ($i/15)"
-              sleep 2
-            done
-          '
-
-      - name: Nginx Post-check diagnostics (on failure)
-        if: failure()
-        run: |
-          docker compose --env-file .env.ci ps
-          docker compose --env-file .env.ci logs --no-color --tail=300 frontend || true
-          docker compose --env-file .env.ci exec -T frontend sh -lc "ps -ef | grep nginx | grep -v grep || true"
-          docker compose --env-file .env.ci exec -T frontend sh -lc "nginx -T 2>/dev/null | sed -n '1,200p' || true"
-
-      - name: Start frontend
-        run: docker compose --env-file .env.ci up -d frontend
-
       - name: Prepare test image
         run: docker compose --env-file .env.ci cp frontend/public/placeholder.jpg backend:/app/uploads/test.jpeg
 
-      - name: Nginx integration check
+      - name: Frontend integration check (wait up to 60s)
         run: |
-          curl -fsI http://localhost/ | grep -i 'content-type: text/html'
-          curl -fsI http://localhost/api/healthz | grep -i '200'
-          curl -fsI http://localhost/uploads/test.jpeg | grep -i 'content-type: image'
+          i=0; ok=0
+          while [ $i -lt 30 ]; do
+            if docker compose --env-file .env.ci exec -T frontend sh -lc '
+              curl -fIs http://localhost/ | grep -q "200 OK" &&
+              [ -f /usr/share/nginx/html/index.html ]'; then
+              echo "[OK] Frontend index ready"; ok=1; break
+            fi
+            echo "Waiting for Nginx static page... ($((i+1))/30)"; i=$((i+1)); sleep 2
+          done
+          if [ $ok -ne 1 ]; then
+            echo "[FAIL] Nginx not ready in time"
+            docker compose --env-file .env.ci exec -T frontend sh -lc 'ps aux | grep nginx; nginx -T | sed -n "1,200p"; ls -lah /usr/share/nginx/html/; head -n 20 /usr/share/nginx/html/index.html; getent hosts backend || true; curl -i http://localhost/ || true'
+            docker compose --env-file .env.ci ps
+            docker compose --env-file .env.ci logs --tail=200 frontend || true
+            exit 1
+          fi
+          i=0; ok=0
+          while [ $i -lt 30 ]; do
+            if docker compose --env-file .env.ci exec -T frontend sh -lc 'curl -fsS http://localhost/api/healthz >/dev/null'; then
+              echo "[OK] /api proxy works"; ok=1; break
+            fi
+            echo "Waiting for /api proxy... ($((i+1))/30)"; i=$((i+1)); sleep 2
+          done
+          if [ $ok -ne 1 ]; then
+            echo "[FAIL] /api proxy not working"
+            docker compose --env-file .env.ci exec -T frontend sh -lc 'getent hosts backend || true; curl -i http://localhost/api/healthz || true'
+            exit 1
+          fi
+          docker compose --env-file .env.ci exec -T frontend sh -lc 'curl -fI http://localhost/uploads/test.jpeg | grep -i "Content-Type: image"'
 
       - name: Tear down
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       - backend_uploads:/app/uploads
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
     logging:
       driver: json-file
@@ -35,7 +40,8 @@ services:
     ports:
       - "80:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     restart: unless-stopped
     logging:
       driver: json-file
@@ -44,6 +50,11 @@ services:
         max-file: "3"
     networks:
       - cslibrary-net
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost/"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   postgres:
     build:

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,7 +2,7 @@
 # Multi-stage build for optimized static file serving
 
 # Build stage
-FROM node:20-alpine AS BUILDER
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
@@ -10,16 +10,14 @@ WORKDIR /app
 ARG VITE_API_BASE="/api"
 ENV VITE_API_BASE=${VITE_API_BASE}
 
-# Copy package files and install dependencies
+# Copy package files and install dependencies, then build
 COPY package*.json ./
 RUN npm ci
-
-# Copy source code and build the application
 COPY . .
 RUN npm run build
 
 # Production stage with Nginx
-FROM nginx:alpine AS PRODUCTION
+FROM nginx:alpine AS production
 
 # Copy custom nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf
@@ -27,14 +25,14 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Ensure static directory exists and set ownership for nginx worker
 RUN mkdir -p /usr/share/nginx/html
 # Copy built application from builder stage with proper ownership
-COPY --chown=nginx:nginx --from=BUILDER /app/dist /usr/share/nginx/html
+COPY --chown=nginx:nginx --from=builder /app/dist /usr/share/nginx/html
 
 # Expose port 80
 EXPOSE 80
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost/ || exit 1
+    CMD curl -fsS http://localhost/ || exit 1
 
 # Start Nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,19 +5,22 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  # SPA fallback
   location / {
-    try_files $uri /index.html;
+    try_files $uri $uri/ /index.html;
   }
 
+  # API proxy
   location /api/ {
     proxy_pass http://backend:8000/;
     proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_http_version 1.1;
   }
 
+  # Static uploads proxy
   location /uploads/ {
-    proxy_pass http://backend:8000/;
+    proxy_pass http://backend:8000/uploads/;
     proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $remote_addr;
   }
 }


### PR DESCRIPTION
## Summary
- fix frontend Dockerfile and nginx config for SPA fallback, API and uploads proxies
- add healthchecks and depends_on in docker-compose
- enhance CI to probe frontend internally with retries and diagnostics

## Testing
- `npm run build`
- `docker compose --env-file .env.ci build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc53e00088323b6198bd941d39909