### PR TITLE
build frontend with nginx production image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,56 +65,43 @@ jobs:
 
       - name: Build frontend
         run: |
-          FRONTEND_DOCKERFILE=frontend/Dockerfile.prod \
-          docker compose --env-file .env.ci build --build-arg VITE_API_BASE=/api frontend
+          docker build -f frontend/Dockerfile.prod --build-arg VITE_API_BASE=/api -t library-frontend ./frontend
 
       - name: Frontend config check
         run: node scripts/check-frontend-config.js
 
-      - name: Start frontend (prod)
-        run: |
-          FRONTEND_DOCKERFILE=frontend/Dockerfile.prod \
-          docker compose --env-file .env.ci up -d frontend
-
-      - name: Nginx Pre-check diagnostics
-        run: |
-          docker compose --env-file .env.ci ps
-          docker compose --env-file .env.ci logs --no-color --tail=200 frontend || true
-
-      - name: Nginx integration check (wait up to 30s)
-        run: |
-          docker compose --env-file .env.ci exec -T frontend sh -lc '
-            i=0
-            until wget -qS --spider http://localhost/ 2>&1 | tr -d "\r" | grep -qiE "^\s*Content-Type:\s*text/html(\s*;.*)?$"; do
-              i=$((i+1))
-              if [ $i -ge 15 ]; then
-                echo "Nginx not serving text/html after ~30s"
-                exit 1
-              fi
-              echo "Waiting for Nginx static page... ($i/15)"
-              sleep 2
-            done
-          '
-
-      - name: Nginx Post-check diagnostics (on failure)
-        if: failure()
-        run: |
-          docker compose --env-file .env.ci ps
-          docker compose --env-file .env.ci logs --no-color --tail=300 frontend || true
-          docker compose --env-file .env.ci exec -T frontend sh -lc "ps -ef | grep nginx | grep -v grep || true"
-          docker compose --env-file .env.ci exec -T frontend sh -lc "nginx -T 2>/dev/null | sed -n '1,200p' || true"
-
       - name: Start frontend
-        run: docker compose --env-file .env.ci up -d frontend
+        run: docker compose --env-file .env.ci up -d --no-build frontend
 
       - name: Prepare test image
         run: docker compose --env-file .env.ci cp frontend/public/placeholder.jpg backend:/app/uploads/test.jpeg
 
-      - name: Nginx integration check
+      - name: Frontend integration check (wait up to 60s)
         run: |
-          curl -fsI http://localhost/ | grep -i 'content-type: text/html'
-          curl -fsI http://localhost/api/healthz | grep -i '200'
-          curl -fsI http://localhost/uploads/test.jpeg | grep -i 'content-type: image'
+          docker compose --env-file .env.ci exec -T frontend sh -lc '
+            i=0
+            until curl -fIs http://localhost/ | grep "200 OK" \
+              && [ -f /usr/share/nginx/html/index.html ] \
+              && curl -fIs http://localhost/api/healthz | grep "200" \
+              && curl -fIs http://localhost/uploads/test.jpeg | grep -i "Content-Type: image/jpeg"; do
+              i=$((i+1))
+              if [ $i -ge 30 ]; then
+                echo "Frontend not ready after ~60s"
+                nginx -T || true
+                ls -lah /usr/share/nginx/html/ || true
+                [ -f /usr/share/nginx/html/index.html ] && head /usr/share/nginx/html/index.html || true
+                exit 1
+              fi
+              echo "Waiting for frontend... ($i/30)"
+              sleep 2
+            done
+          '
+
+      - name: Frontend diagnostics (on failure)
+        if: failure()
+        run: |
+          docker compose --env-file .env.ci ps
+          docker compose --env-file .env.ci logs --no-color --tail=300 frontend || true
 
       - name: Tear down
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,11 @@ services:
         max-file: "3"
     networks:
       - cslibrary-net
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   frontend:
     build:
@@ -35,7 +40,8 @@ services:
     ports:
       - "80:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     restart: unless-stopped
     logging:
       driver: json-file
@@ -44,6 +50,11 @@ services:
         max-file: "3"
     networks:
       - cslibrary-net
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   postgres:
     build:

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,40 +1,30 @@
-# Frontend Production Dockerfile
-# Multi-stage build for optimized static file serving
+# Frontend production multi-stage Dockerfile
 
 # Build stage
-FROM node:20-alpine AS BUILDER
-
+FROM node:20-alpine AS builder
 WORKDIR /app
 
-# Build-time API base (default to relative path for Nginx reverse proxy)
+# Build-time API base for Nginx reverse proxy
 ARG VITE_API_BASE="/api"
 ENV VITE_API_BASE=${VITE_API_BASE}
 
-# Copy package files and install dependencies
+# Install dependencies and build
 COPY package*.json ./
 RUN npm ci
-
-# Copy source code and build the application
 COPY . .
 RUN npm run build
 
 # Production stage with Nginx
-FROM nginx:alpine AS PRODUCTION
+FROM nginx:alpine AS production
 
-# Copy custom nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Install curl for health checks
+RUN apk add --no-cache curl
 
-# Ensure static directory exists and set ownership for nginx worker
-RUN mkdir -p /usr/share/nginx/html
-# Copy built application from builder stage with proper ownership
-COPY --chown=nginx:nginx --from=BUILDER /app/dist /usr/share/nginx/html
+# Copy Nginx configuration
+COPY conf.d/default.conf /etc/nginx/conf.d/default.conf
 
-# Expose port 80
+# Copy built assets
+COPY --from=builder /app/dist /usr/share/nginx/html
+
 EXPOSE 80
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost/ || exit 1
-
-# Start Nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/conf.d/default.conf
+++ b/frontend/conf.d/default.conf
@@ -1,3 +1,5 @@
+include /etc/nginx/mime.types;
+
 server {
   listen 80;
   server_name _;
@@ -6,7 +8,7 @@ server {
   index index.html;
 
   location / {
-    try_files $uri /index.html;
+    try_files $uri $uri/ /index.html;
   }
 
   location /api/ {
@@ -16,7 +18,7 @@ server {
   }
 
   location /uploads/ {
-    proxy_pass http://backend:8000/;
+    proxy_pass http://backend:8000/uploads/;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $remote_addr;
   }


### PR DESCRIPTION
## Summary
- build frontend image using dedicated production Dockerfile
- serve SPA via nginx with API and uploads reverse proxies
- add container healthchecks and CI integration test for frontend

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'main')*


------
https://chatgpt.com/codex/tasks/task_e_68be710da188832397d62c52effe86fc