### PR TITLE
chore: avoid dev deps in backend prod image

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -15,15 +15,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements and create wheels
-ARG INCLUDE_DEV_REQS="false"
-COPY requirements.txt requirements.dev.txt ./
+# Copy requirements and create wheels (production only)
+COPY requirements.txt ./
 RUN pip install --upgrade pip setuptools wheel && \
-    if [ "$INCLUDE_DEV_REQS" = "true" ]; then \
-        pip wheel --wheel-dir /wheels -r requirements.dev.txt; \
-    else \
-        pip wheel --wheel-dir /wheels -r requirements.txt; \
-    fi
+    pip wheel --wheel-dir /wheels -r requirements.txt
 
 ## Runtime stage
 FROM python:3.11-slim AS runtime


### PR DESCRIPTION
## Summary
- remove dev requirements references from backend/Dockerfile.prod so final image only installs prod wheels

## Testing
- `make check-backend` *(fails: here-document at line 1 delimited by end-of-file (wanted `PY`))*
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68c6492e7f64832397150ba3598aab2f